### PR TITLE
background: Call queue_draw() in do_draw while animation is running

### DIFF
--- a/src/background/background.cpp
+++ b/src/background/background.cpp
@@ -120,9 +120,14 @@ gboolean BackgroundDrawingArea::update_animation(Glib::RefPtr<Gdk::FrameClock> f
 
 bool BackgroundDrawingArea::do_draw(const Cairo::RefPtr<Cairo::Context>& cr, int width, int height)
 {
-    if (!to_image)
+    if (!to_image || !to_image->source)
     {
         return false;
+    }
+
+    if (fade.running())
+    {
+        queue_draw();
     }
 
     auto to_adjustments = to_image->generate_adjustments(width, height);


### PR DESCRIPTION
This makes the background fade transitions smoother, when using a directory of images.