### PR TITLE
background: Optimize texture uploading by only calling glTexImage2D once

### DIFF
--- a/src/background/background.hpp
+++ b/src/background/background.hpp
@@ -21,11 +21,14 @@ class BackgroundImageAdjustments
 class BackgroundImage
 {
   public:
+    BackgroundImage();
+    ~BackgroundImage();
     Glib::RefPtr<Gdk::Pixbuf> source;
     std::string fill_type;
     Glib::RefPtr<BackgroundImageAdjustments> adjustments;
 
     void generate_adjustments(int width, int height);
+    GLuint tex_id = 0;
 };
 
 class BackgroundGLArea : public Gtk::GLArea
@@ -42,8 +45,6 @@ class BackgroundGLArea : public Gtk::GLArea
      * pbuf2 is the image from which we are fading. x and y
      * are used as offsets when preserve aspect is set. */
     Glib::RefPtr<BackgroundImage> to_image, from_image;
-    GLuint from_tex = 0;
-    GLuint to_tex   = 0;
 
   public:
     BackgroundGLArea(WayfireBackground *background);


### PR DESCRIPTION
Before, we were uploading a texture twice: once when it's picked and once after it switches to fade out. This makes it so the old texture id is reused when fading to a new image, and avoids a call to glTexImage2D.