### PR TITLE
shell-app: set argc/argv when running gtk app

### DIFF
--- a/src/background/background.cpp
+++ b/src/background/background.cpp
@@ -630,9 +630,9 @@ class WayfireBackgroundApp : public WayfireShellApp
     static void create(int argc, char **argv)
     {
         WayfireShellApp::instance =
-            std::make_unique<WayfireBackgroundApp>(argc, argv);
+            std::make_unique<WayfireBackgroundApp>();
         g_unix_signal_add(SIGUSR1, sigusr1_handler, (void*)instance.get());
-        instance->run();
+        instance->run(argc, argv);
     }
 
     void handle_new_output(WayfireOutput *output) override

--- a/src/dock/dock-app.cpp
+++ b/src/dock/dock-app.cpp
@@ -1,7 +1,6 @@
 #include "dock.hpp"
 #include "toplevel.hpp"
 #include "toplevel-icon.hpp"
-#include "glibmm.h"
 #include <iostream>
 #include <gdk/wayland/gdkwayland.h>
 #include <css-config.hpp>
@@ -148,12 +147,11 @@ void WfDockApp::create(int argc, char **argv)
         throw std::logic_error("Running WfDockApp twice!");
     }
 
-    instance = std::unique_ptr<WfDockApp>{new WfDockApp(argc, argv)};
-    instance->run();
+    instance = std::unique_ptr<WfDockApp>{new WfDockApp()};
+    instance->run(argc, argv);
 }
 
-WfDockApp::WfDockApp(int argc, char **argv) :
-    WayfireShellApp(argc, argv), priv(new WfDockApp::impl())
+WfDockApp::WfDockApp() : WayfireShellApp(), priv(new WfDockApp::impl())
 {}
 WfDockApp::~WfDockApp() = default;
 

--- a/src/dock/dock.cpp
+++ b/src/dock/dock.cpp
@@ -3,9 +3,6 @@
 #include <glibmm/main.h>
 #include <gdk/wayland/gdkwayland.h>
 
-#include <iostream>
-#include <map>
-
 #include <gtk-utils.hpp>
 #include <wf-shell-app.hpp>
 #include <gtk4-layer-shell.h>

--- a/src/dock/dock.hpp
+++ b/src/dock/dock.hpp
@@ -1,12 +1,11 @@
 #ifndef WF_DOCK_HPP
 #define WF_DOCK_HPP
 
-#include <map>
 #include <gtkmm/box.h>
 #include <wayland-client.h>
 
-#include "toplevel-icon.hpp"
 #include "wf-shell-app.hpp"
+#include "wlr-foreign-toplevel-management-unstable-v1-client-protocol.h"
 #include <wf-option-wrap.hpp>
 
 class WfDock
@@ -45,7 +44,7 @@ class WfDockApp : public WayfireShellApp
     void handle_output_removed(WayfireOutput *output) override;
 
   private:
-    WfDockApp(int argc, char **argv);
+    WfDockApp();
 
     class impl;
     std::unique_ptr<impl> priv;

--- a/src/panel/panel.cpp
+++ b/src/panel/panel.cpp
@@ -6,16 +6,12 @@
 #include <gdk/wayland/gdkwayland.h>
 #include <gtk4-layer-shell.h>
 
-#include <stdio.h>
 #include <iostream>
 #include <sstream>
 
 #include <map>
-#include <filesystem>
 #include <css-config.hpp>
-
 #include "panel.hpp"
-#include "../util/gtk-utils.hpp"
 
 #include "widgets/battery.hpp"
 #include "widgets/command-output.hpp"
@@ -410,13 +406,12 @@ void WayfirePanelApp::create(int argc, char **argv)
         throw std::logic_error("Running WayfirePanelApp twice!");
     }
 
-    instance = std::unique_ptr<WayfireShellApp>(new WayfirePanelApp{argc, argv});
-    instance->run();
+    instance = std::unique_ptr<WayfireShellApp>(new WayfirePanelApp{});
+    instance->run(argc, argv);
 }
 
 WayfirePanelApp::~WayfirePanelApp() = default;
-WayfirePanelApp::WayfirePanelApp(int argc, char **argv) :
-    WayfireShellApp(argc, argv), priv(new impl())
+WayfirePanelApp::WayfirePanelApp() : WayfireShellApp(), priv(new impl())
 {}
 
 int main(int argc, char **argv)

--- a/src/panel/panel.hpp
+++ b/src/panel/panel.hpp
@@ -39,7 +39,7 @@ class WayfirePanelApp : public WayfireShellApp
     void on_config_reload() override;
 
   private:
-    WayfirePanelApp(int argc, char **argv);
+    WayfirePanelApp();
 
 
     class impl;

--- a/src/util/wf-shell-app.cpp
+++ b/src/util/wf-shell-app.cpp
@@ -124,6 +124,7 @@ void WayfireShellApp::add_css_file(std::string file, int priority)
 bool WayfireShellApp::parse_cfgfile(const Glib::ustring & option_name,
     const Glib::ustring & value, bool has_value)
 {
+    std::cout << "%%%%%%%%%%%%%%%%%%%%%%%" << std::endl;
     std::cout << "Using custom config file " << value << std::endl;
     cmdline_config = value;
     return true;
@@ -284,8 +285,9 @@ void WayfireShellApp::rem_output(GMonitor monitor)
     }
 }
 
-WayfireShellApp::WayfireShellApp(int argc, char **argv)
+WayfireShellApp::WayfireShellApp()
 {
+    std::cout << "setting up" << std::endl;
     app = Gtk::Application::create("", Gio::Application::Flags::HANDLES_COMMAND_LINE);
     app->signal_activate().connect(
         sigc::mem_fun(*this, &WayfireShellApp::on_activate));
@@ -312,9 +314,9 @@ WayfireShellApp& WayfireShellApp::get()
     return *instance;
 }
 
-void WayfireShellApp::run()
+void WayfireShellApp::run(int argc, char **argv)
 {
-    app->run();
+    app->run(argc, argv);
 }
 
 /* -------------------------- WayfireOutput --------------------------------- */

--- a/src/util/wf-shell-app.hpp
+++ b/src/util/wf-shell-app.hpp
@@ -1,7 +1,6 @@
 #ifndef WF_SHELL_APP_HPP
 #define WF_SHELL_APP_HPP
 
-#include <set>
 #include <string>
 #include <wayfire/config/config-manager.hpp>
 
@@ -70,12 +69,12 @@ class WayfireShellApp
     wf::config::config_manager_t config;
     zwf_shell_manager_v2 *wf_shell_manager = nullptr;
 
-    WayfireShellApp(int argc, char **argv);
+    WayfireShellApp();
     virtual ~WayfireShellApp();
 
     virtual std::string get_config_file();
     virtual std::string get_css_config_dir();
-    virtual void run();
+    virtual void run(int argc, char **argv);
 
     virtual void on_config_reload()
     {}


### PR DESCRIPTION
The current impl never sends argc/argv to gtk so we never parse arguments.